### PR TITLE
use exif GPSLongitudeRef/GPSLatitudeRef to capture signs of coordinat…

### DIFF
--- a/src/components/Camera.tsx
+++ b/src/components/Camera.tsx
@@ -61,6 +61,7 @@ export function Camera(props: CameraProps) {
     const pickerResult = await ImagePicker.launchImageLibraryAsync({ exif: true })
 
     if (!pickerResult.cancelled) {
+      console.log(pickerResult.exif)
       setSelectedPhotoUri(pickerResult.uri)
       props.onTakePicture(pickerResult)
     }

--- a/src/components/CameraWithLocation.tsx
+++ b/src/components/CameraWithLocation.tsx
@@ -40,7 +40,12 @@ export function CameraWithLocation(props: CameraWithLocationProps) {
           accuracy: Location.Accuracy.BestForNavigation,
         })
 
-        return { latitude: location.coords.latitude, longitude: location.coords.longitude }
+        const decimals = 1000000
+        const roundedLatitude = Math.round(location.coords.latitude * decimals) / decimals
+        const roundedLongitude = Math.round(location.coords.longitude * decimals) / decimals
+        console.log("location from device", location, location.coords)
+        console.log("rounded", roundedLatitude, roundedLongitude)
+        return { latitude: roundedLatitude, longitude: roundedLongitude }
       }
     } catch (error) {
       if (__DEV__) {
@@ -58,13 +63,23 @@ export function CameraWithLocation(props: CameraWithLocationProps) {
       return null
     }
 
-    const latitude: number | undefined = capturedPicture.exif.GPSLatitude
-    const longitude: number | undefined = capturedPicture.exif.GPSLongitude
+    var latitude: number | undefined = capturedPicture.exif.GPSLatitude
+    if (capturedPicture.exif.GPSLatudeRef == "S") {
+      latitude = latitude * -1
+    }
+    var longitude: number | undefined = capturedPicture.exif.GPSLongitude
+    if (capturedPicture.exif.GPSLongitudeRef == "W") {
+      longitude = longitude * -1
+    }
 
     if (!latitude || !longitude) {
       return null
     }
-
+    console.log("exif lon", longitude)
+    console.log("exif lat", latitude)
+    const timestring = capturedPicture.exif.DateTimeOriginal
+    const offset = capturePicture.exif.OffsetTimeOriginal
+    console.log("captured", timestring, offset)
     return { latitude, longitude }
   }
 
@@ -72,6 +87,7 @@ export function CameraWithLocation(props: CameraWithLocationProps) {
     setIsLocatDialogVisible(true)
 
     const coordsFromExif = getLocationFromExif(capturedPicture)
+    console.log("coordsFromExif", coordsFromExif)
 
     if (!!coordsFromExif) {
       props.onTakePictureFinish({ capturedPicture, coords: coordsFromExif })

--- a/src/screens/AddTreeScreen/AddTreeScreen.tsx
+++ b/src/screens/AddTreeScreen/AddTreeScreen.tsx
@@ -42,7 +42,6 @@ function validateForm(values: FormValues): FormikErrors<FormValues> {
   if (!values.photo) {
     errors.photo = 'You have to add photo'
   }
-
   if (!values.speciesData) {
     errors.speciesData = "Can't be blank"
   }


### PR DESCRIPTION
…es from Library photos. Round device latitude/longitude for live photos.

Two different techniques are used to determine tree location. 

For a photo taken live, the device's location is used. That's the path that occasionally puts new photos into the wrong hemisphere. This PR rounds down latitude and longitude in hopes of avoiding overflow/sign loss. This will be tough to verify as a fix because it's intermittent.

For a photo pulled from the library/camera roll, the photo's EXIF data is used. GPSLatitudeRef and GPSLongitudeRef were being ignored, placing all photos with west longitude or south latitude in the wrong hemisphere. This path has been fixed verifiably.