### PR TITLE
Image Rotation Fix

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
 		"slug": "iSeaTree",
 		"privacy": "public",
 		"platforms": [ "ios", "android" ],
-		"version": "1.0.1",
+		"version": "1.0.2",
 		"orientation": "default",
 		"icon": "./assets/icon.png",
 		"splash": {
@@ -19,7 +19,7 @@
 		"android": {
 			"permissions": [ "ACCESS_COARSE_LOCATION", "ACCESS_FINE_LOCATION", "CAMERA" ],
 			"package": "com.treemama.iseatree",
-			"versionCode": 17,
+			"versionCode": 18,
 			"config": {
 				"googleMaps": {
 					"apiKey": "AIzaSyBCXyRI_JS7_wQzLbPHMvF3HTJP-2zrN2s"
@@ -43,7 +43,7 @@
 		"ios": {
 			"icon": "./assets/icon.png",
 			"bundleIdentifier": "com.treemama.iseatree",
-			"buildNumber": "17",
+			"buildNumber": "18",
 			"supportsTablet": true,
 			"infoPlist": {
 				"NSCameraUsageDescription": "We use the camera to allow you to take a photo and submit it with your iSeaTree reports.",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "expo-camera": "~8.2.0",
     "expo-constants": "~9.0.0",
     "expo-device": "~2.1.0",
+    "expo-image-manipulator": "~8.1.0",
     "expo-location": "~8.1.0",
     "firebase": "7.9.0",
     "formik": "^2.1.4",

--- a/src/components/Camera.tsx
+++ b/src/components/Camera.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
 
 import { MaterialCommunityIcons } from '@expo/vector-icons'
-import { View, Image, Alert } from 'react-native'
+import { View, Image, Alert, Platform } from 'react-native'
 import { Camera as ExpoCamera } from 'expo-camera'
 import { Text, Button } from 'react-native-paper'
+import * as ImageManipulator from 'expo-image-manipulator'
 
 import { StatusBar } from './StatusBar'
 
@@ -45,7 +46,17 @@ export function Camera(props: CameraProps) {
 
     cameraRefObj.takePictureAsync({ exif: true, quality: 0.6 }).then((photo) => {
       cameraRefObj.pausePreview()
-      props.onTakePicture(photo)
+      if (Platform.OS === 'android' && photo.exif.Orientation === 6) {
+        console.log('Image is rotated. Fixing.')
+        ImageManipulator.manipulateAsync(photo.uri, [{ rotate: -90 }], {
+          compress: 1,
+          format: ImageManipulator.SaveFormat.JPEG,
+        }).then((fixedPhoto) => {
+          props.onTakePicture(fixedPhoto)
+        })
+      } else {
+        props.onTakePicture(photo)
+      }
     })
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3150,6 +3150,11 @@ expo-font@~8.1.0:
     fbjs "1.0.0"
     fontfaceobserver "^2.1.0"
 
+expo-image-manipulator@~8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/expo-image-manipulator/-/expo-image-manipulator-8.1.0.tgz#63ae66e1a65e5be8c6ee7036fe88d53af551853f"
+  integrity sha512-ephPXtzEx32Js1SQ1B2IXdpi4Gn34DIMQGAOwrwOPfUuWXQX9jGxyX3tktIGMmQ7lHueVr0a8zdh6ME0YGHjkw==
+
 expo-keep-awake@~8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/expo-keep-awake/-/expo-keep-awake-8.1.0.tgz#3a1d8aa5a8395d40c7d79e1c93020ae5f848e664"


### PR DESCRIPTION
[Problem]
On some Android devices, when the device rotation is locked,
the image is rotated 90 degrees.

[Solution]
Checked if the Exif:Orientation is 6 (rotated 90 degrees). If yes,
used Expo:ImageManipulation library to rotate the image -90
degrees, only on Android devices.

[Note]
This fixes the rotation of the image taken in portrait mode when
the device rotation is locked, but, as a consequence it also applies
the rotation to images taken in landscape mode when the device
rotation is locked. Unfortunately, there is no way to differentiate
between these two scenarios.

[Test]
Verified that the images taken in portrait mode when the device
rotation is locked shows up correctly. Also, verified that there
are no regressions while taking images when device rotation is
unlocked.