### PR TITLE
Feature/fix login

### DIFF
--- a/src/screens/LoginScreen/LoginScreen.tsx
+++ b/src/screens/LoginScreen/LoginScreen.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { StyleSheet, View } from 'react-native'
+import { StyleSheet, View, ScrollView } from 'react-native'
 import { Banner, Button } from 'react-native-paper'
 import * as firebase from 'firebase'
 
@@ -47,24 +47,26 @@ export function LoginScreen() {
 
   return (
     <View style={styles.container}>
-      <Banner
-        visible={!!errorMessage}
-        actions={[{ label: 'OK', onPress: () => setErrorMessage(null) }]}
-      >
-        {errorMessage ? errorMessage : ''}
-      </Banner>
+      <ScrollView style={{ flex: 1, backgroundColor: '#fff' }}>
+        <Banner
+          visible={!!errorMessage}
+          actions={[{ label: 'OK', onPress: () => setErrorMessage(null) }]}
+        >
+          {errorMessage ? errorMessage : ''}
+        </Banner>
 
-      <View style={styles.content}>
-        <LoginForm
-          headlineText="Log in to your account"
-          submitText="Log in"
-          onSubmit={handleLogin}
-          isLoading={isLoading}
-        />
-        <Button style={{ marginTop: 10 }} onPress={navigationActions.resetPassword}>
-          Forgot your password?
-        </Button>
-      </View>
+        <View style={styles.content}>
+          <LoginForm
+            headlineText="Log in to your account"
+            submitText="Log in"
+            onSubmit={handleLogin}
+            isLoading={isLoading}
+          />
+          <Button style={{ marginTop: 10 }} onPress={navigationActions.resetPassword}>
+            Forgot your password?
+          </Button>
+        </View>
+      </ScrollView>
 
       <Button style={{ marginTop: 10, marginBottom: 20 }} onPress={navigationActions.register}>
         create new account

--- a/src/screens/LoginScreen/LoginScreen.tsx
+++ b/src/screens/LoginScreen/LoginScreen.tsx
@@ -47,7 +47,7 @@ export function LoginScreen() {
 
   return (
     <View style={styles.container}>
-      <ScrollView style={{ flex: 1, backgroundColor: '#fff' }}>
+      <ScrollView>
         <Banner
           visible={!!errorMessage}
           actions={[{ label: 'OK', onPress: () => setErrorMessage(null) }]}


### PR DESCRIPTION
there is **ScrollView** tag that wraps all **registerScreen** (i guess primary use you can scroll when content is inside of this tag). Inside of this tag you can click outside of input and it dismiss keyboard. When you click outside of input on **loginScreen** keyboard stays on screen because input is not inside **ScrollView**. To keep same component spacing on iphone, **ScrollView** wraps only content without create new account button. But I can wrap all content if you don't mind that create new account is not going to sit at bottom of the screen but moves closer to forgot your password button on iphone. Simulator displays spacing as it suppose to be when everything is wrapped inside **ScrollView** tag. This is my first react-native project so I don't know if I can do an easy fix to to make it work other way.