### PR TITLE
Button nav

### DIFF
--- a/src/LoggedTabNavigator.tsx
+++ b/src/LoggedTabNavigator.tsx
@@ -22,7 +22,7 @@ export function LoggedTabNavigator() {
   return (
     <Tab.Navigator
       activeColor={theme.colors.primary}
-      barStyle={{ paddingBottom: 5, backgroundColor: 'white' }}
+      barStyle={{ paddingBottom: 8, backgroundColor: 'white' }}
       labeled
     >
       <Tab.Screen
@@ -60,7 +60,7 @@ export function LoggedTabNavigator() {
             <Image
               source={focused ? treeCameraActiveIcon : treeCameraIcon}
               fadeDuration={0}
-              style={{ width: 30, height: 30 }}
+              style={{ width: 26, height: 26 }}
             />
           ),
         }}

--- a/src/screens/AddTreeScreen/AddTreeScreen.tsx
+++ b/src/screens/AddTreeScreen/AddTreeScreen.tsx
@@ -270,7 +270,8 @@ export function AddTreeScreen() {
               }} />
             </View>
             <View style={{ position: 'absolute',top:5, right: 30 }}>
-              <Button mode="outlined" uppercase={true} style={{ backgroundColor: 'white', height: 30, width: 80 }} labelStyle={{ color: 'green', fontSize: 11 }}
+
+              <Button mode="outlined" uppercase={true} style={{ backgroundColor: 'white', height: 40, width: 120 }} labelStyle={{ color: 'green', fontSize: 11 }}
                 onPress={() => {
                   console.log('clear')
                   formik.setFieldValue('speciesType', TreeTypes.NULL)


### PR DESCRIPTION
fixes #81 This commit increases the size of the clear button on the AddTreeScreen. Also in LoggedTabNavigator adds 3px padding to the bottom of the navbar and makes the camera image smaller. 