### PR TITLE
fixes 'calculate tree benefits button is enabled when species is unknown'

### DIFF
--- a/src/screens/AddTreeScreen/TreeBenefits.tsx
+++ b/src/screens/AddTreeScreen/TreeBenefits.tsx
@@ -52,14 +52,15 @@ export function TreeBenefits(props: TreeBenefitsProps) {
   const { crownLightExposureCategory, dbh, speciesData, treeConditionCategory } = values;
 
   const canCalculateBenefits = !!(
-    speciesData
+    speciesData 
+    && speciesData.TYPE.toLowerCase() !== "unknown"
     && crownLightExposureCategory
     && dbh
     && speciesData
     && treeConditionCategory);
 
   const loadBenefits = async() => {
-    if (speciesData && speciesData.ID) {
+    if (canCalculateBenefits && speciesData && speciesData.ID) {
       const url = `${CONFIG.API_TREE_BENEFIT}?`
       + `key=${CONFIG.ITREE_KEY}&`
       + `NationFullName=${CONFIG.NATION}&`


### PR DESCRIPTION
This fixes an issue where the 'calculate tree benefits' button was showing as enabled though the species was 'unknown'. canCalculateBenfits function was changed so it checks if species.TYPE is unknown and thus sets the flag to false.

canCalculateBenefits was also added as a validation to the 'calculate'-button event handler so there is a common business logic applied.