### PR TITLE
Fixes "Fully Shaded" issue and enlarges Close buttons

### DIFF
--- a/data/crown_light_exposures.json
+++ b/data/crown_light_exposures.json
@@ -1,14 +1,14 @@
 [
   {
     "label": "Fully Exposed to Light",
-    "value": 5
+    "value": "5"
   },
   {
     "label": "Partially Shaded",
-    "value": 3
+    "value": "3"
   },
   {
     "label": "Fully Shaded",
-    "value": 0
+    "value": "0"
   }
 ]

--- a/src/screens/AddTreeScreen/AddTreeScreen.tsx
+++ b/src/screens/AddTreeScreen/AddTreeScreen.tsx
@@ -52,13 +52,16 @@ function validateForm(values: FormValues): FormikErrors<FormValues> {
   if (values.dbh === '') {
     errors.dbh = "Can't be blank"
   }
+  if (values.dbh === '0') {
+    errors.dbh = "Can't be zero"
+  }
   if (!values.landUseCategory) {
     errors.landUseCategory = "Can't be blank"
   }
   if (!values.treeConditionCategory) {
     errors.treeConditionCategory = "Can't be blank"
   }
-  if (!values.crownLightExposureCategory) {
+  if (values.crownLightExposureCategory === null) {
     errors.crownLightExposureCategory = "Can't be blank"
   }
 
@@ -179,6 +182,7 @@ export function AddTreeScreen() {
     },
     validate: validateForm,
     onSubmit: (values) => {
+      // alert(JSON.stringify(values, null, 2));
       submitTreeData(values).then(handleAddTreeSuccess).catch(handleAddTreeError)
     },
   })

--- a/src/screens/AddTreeScreen/CrownLightExposureSelect.tsx
+++ b/src/screens/AddTreeScreen/CrownLightExposureSelect.tsx
@@ -27,11 +27,7 @@ export function CrownLightExposureSelect(props: CrownLightExposureCategorySelect
       value={props.crownLightExposureCategoryName}
       items={selectItems}
       onValueChange={(value) => {
-        if (!value) {
-          props.onValueChange(null)
-        } else {
-          props.onValueChange(value)
-        }
+        props.onValueChange(value)
       }}
       placeholder={{
         label: 'Select crown light exposure category...',

--- a/src/screens/AddTreeScreen/DbhHelp.tsx
+++ b/src/screens/AddTreeScreen/DbhHelp.tsx
@@ -98,7 +98,7 @@ export function DbhHelp() {
 
           <Button
             mode="contained"
-            style={{ borderRadius: 0 }}
+            style={{ borderRadius: 0, padding: 15 }}
             onPress={() => {
               setIsModalVisible(false)
             }}

--- a/src/screens/AddTreeScreen/TreeBenefits.tsx
+++ b/src/screens/AddTreeScreen/TreeBenefits.tsx
@@ -52,15 +52,15 @@ export function TreeBenefits(props: TreeBenefitsProps) {
   const { crownLightExposureCategory, dbh, speciesData, treeConditionCategory } = values;
 
   const canCalculateBenefits = !!(
-    speciesData 
+    speciesData
     && speciesData.TYPE.toLowerCase() !== "unknown"
-    && crownLightExposureCategory
+    && crownLightExposureCategory !== null
     && dbh
-    && speciesData
+    && dbh !== "0"
     && treeConditionCategory);
 
   const loadBenefits = async() => {
-    if (canCalculateBenefits && speciesData && speciesData.ID) {
+    if (canCalculateBenefits) {
       const url = `${CONFIG.API_TREE_BENEFIT}?`
       + `key=${CONFIG.ITREE_KEY}&`
       + `NationFullName=${CONFIG.NATION}&`
@@ -222,7 +222,7 @@ export function TreeBenefits(props: TreeBenefitsProps) {
 
             <Button
               mode="contained"
-              style={{ borderRadius: 0 }}
+              style={{ borderRadius: 0, padding: 15 }}
               onPress={() => {
                 setIsModalVisible(false)
               }}

--- a/src/screens/AddTreeScreen/TtypeHelp.tsx
+++ b/src/screens/AddTreeScreen/TtypeHelp.tsx
@@ -35,7 +35,7 @@ export function TtypeHelp() {
           </View>
           <Button
             mode="contained"
-            style={{ borderRadius: 0, position: 'absolute', bottom: 5, width: '100%' }}
+            style={{ borderRadius: 0, position: 'absolute', bottom: 0, padding: 15, width: '100%' }}
             onPress={() => {
               setIsModalVisible(false)
             }}


### PR DESCRIPTION
Here's what I did:
1) Removed the `!value` check in the dropdown because a 0 value would trigger this and reset it to null. 
2) Then changed the logic to check for null values instead of falsey values
3) Also added checks for 0 value for the DBH
4) When I tried to submit a tree that is 'Fully Shaded' I got the following error:
`'There was an unexpected error (AddTreeScreen::handleAddTree). Please try again later.', `
5) Not very helpful, so I thought it might be a type error, so I changed the CLE values in the JSON file to strings and it went through.

I don't know if this is the right fix, but I got it to work.

I also noticed the "Close/Done" buttons on the modals are hard to tap on iphones with no home button because the "bar" is in the way (see below), so I increased the height to make them easier to tap.
![IMG_4768](https://user-images.githubusercontent.com/44694525/101853917-56b53400-3b15-11eb-97a9-4e27fef9cf6f.PNG)
