### PR TITLE
Issue/455

### DIFF
--- a/src/screens/InfoScreen/InfoScreen.tsx
+++ b/src/screens/InfoScreen/InfoScreen.tsx
@@ -63,62 +63,52 @@ export function InfoScreen(props) {
   // auto-fill selectedTree state when navigated from MapScreen; show TreeInfo
   useEffect(() => {
     const { params } = props.route
-    if (params && params.treeNameQuery !== undefined) {
-      const completeList = speciesDataList
-      let query = params.treeNameQuery?.toUpperCase().toString();
-      console.log(`query: ${query}`);
-      // const filteredList = completeList.filter(
-      //   (tree) => tree.COMMON.toUpperCase().indexOf(query) > -1,
-      // )
 
+    if (!params || params.treeNameQuery === undefined) {
+      return;
+    }
 
-      // Replace double-quotes with single-quotes to match pattern in datastore
-      if (query.includes('"')) {
-        query.replace(/"/g, "'");
-      }
+    
+      const completeList = speciesDataList;
+      const query = params.treeNameQuery?.toUpperCase().toString();
       
+      // Replace double-quotes with single-quotes to match pattern in datastore
+      const normalizedQuery = query.replace(/"/g, "'");
+
       // Create a Regular Expression based on the query
-      let reg = new RegExp(`^${query}$`)
+      let reg = new RegExp(`^${normalizedQuery}$`);
       console.log(reg);
 
-      let filteredList;
 
       // Filter tree list by scientific name using search(regex) to find a match
-      const filterByScientific= (list, regex) => {
-        return list.filter((tree) => tree.SCIENTIFIC.toUpperCase().search(regex) > -1)
-      }
+      const filterByScientific= (list, regex) => 
+         list.filter((tree) => tree.SCIENTIFIC.toUpperCase().search(regex) > -1);
+      
 
-      let scientificList = filterByScientific(completeList, reg)
+      let filteredList = filterByScientific(completeList, reg)
 
-
-      console.log(scientificList);
-
-      if (scientificList.length === 0){
+      if (filteredList.length === 0){
         console.log('No matches found in scientific list, first trimming query')
         let trim = query.match(/'.*'/g) || query.match(/‘.*?’/g, '');
         let trimmedQuery = query.replace(` ${trim}`, '');
         console.log(`trimmedQuery: ${trimmedQuery}, trim: ${trim}`);
-        scientificList = filterByScientific(completeList, new RegExp(`^${trimmedQuery}$`));
+        filteredList = filterByScientific(completeList, new RegExp(`^${trimmedQuery}$`));
       }
 
 
-      if (scientificList.length === 0) {
+      if (filteredList.length === 0) {
         console.log("Still no matches found in scientific list, checking common name")
         filteredList = completeList.filter(
           (tree) => tree.COMMON.toUpperCase().search(reg) > -1
-        )
-      } else {
-        filteredList = scientificList;
-      }
+        );
+      } 
+      
 
-
-
-      // setSelectedTree(filteredList.length == 0 ? undefined : filteredList[0])
       setSelectedTree(filteredList.length == 0 ? undefined : filteredList[0])
       
       setIsFromMapScreen(true)
-    }
-  }, [props.route])
+    
+  }, [props.route, speciesDataList]);
 
   // filters logic
   useEffect(() => {

--- a/src/screens/InfoScreen/InfoScreen.tsx
+++ b/src/screens/InfoScreen/InfoScreen.tsx
@@ -66,10 +66,15 @@ export function InfoScreen(props) {
     if (params && params.treeNameQuery !== undefined) {
       const completeList = speciesDataList
       const query = params.treeNameQuery?.toUpperCase()
-      const filteredList = completeList.filter(
-        (tree) => tree.COMMON.toUpperCase().indexOf(query) > -1,
+      // const filteredList = completeList.filter(
+      //   (tree) => tree.COMMON.toUpperCase().indexOf(query) > -1,
+      // )
+      const scientificList = completeList.filter(
+        (tree) => tree.SCIENTIFIC.toUpperCase().indexOf(query) > -1,
       )
-      setSelectedTree(filteredList.length == 0 ? undefined : filteredList[0])
+
+      // setSelectedTree(filteredList.length == 0 ? undefined : filteredList[0])
+      setSelectedTree(scientificList.length == 0 ? undefined : scientificList[0])
       setIsFromMapScreen(true)
     }
   }, [props.route])

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -427,16 +427,21 @@ export function MapScreen(props: { navigation: MapScreenNavigation }) {
     )
   }
 
+  // function extractTreeNameQuery(item) {
+  //   const treename = item.item.speciesNameCommon
+  //   console.log(
+  //     'Extracted Tree Common Name: ' +
+  //       treename +
+  //       '  from tooltip. Passing to InfoScreen to show more tree info',
+  //   )
+  //   return treename
+  // }
   function extractTreeNameQuery(item) {
-    const treename = item.item.speciesNameCommon
-    console.log(
-      'Extracted Tree Common Name: ' +
-        treename +
-        '  from tooltip. Passing to InfoScreen to show more tree info',
-    )
+    const treename = item.item.speciesNameScientific ? item.item.speciesNameScientific : item.item.speciesNameCommon;
+    console.log (` Extracted Tree Name:  ${treename}`);
     return treename
   }
-
+  
   // navigate to Tree Info screen to show MORE TREE INFO
   const onSuggestedTree = async (item) => {
     props.navigation.navigate('infoScreen', {


### PR DESCRIPTION
The solution to issue: 455 (https://github.com/TreeMama/iSeaTree-React-Prototype/issues/455):

The code was updated to filter the tree list by Scientific Names instead of Common Names. The updated code normalizes the query string by replacing any double-quotes with single-quotes to match the pattern in the data store, creates a regular expression based on the normalized query, and then filters the tree list by scientific name using the search method. If no matches are found, the query is trimmed and filtered again. If there are still no matches, the tree list is filtered by common name. The selected tree is then set to the first item in the filtered list, or undefined if the list is empty.