### PR TITLE
Update species.json

### DIFF
--- a/data/species.json
+++ b/data/species.json
@@ -7532,7 +7532,7 @@
   {
     "COMMON": "Manilla Palm (or The Christmas Palm)",
     "TYPE": "broadleaf",
-    "SCIENTIFIC": "Adonidia merrilli",
+    "SCIENTIFIC": "Adonidia merrillii",
     "ID": "284",
     "ITREECODE": "ADME",
     "LEVEL": "medium",


### PR DESCRIPTION
Fixed typo in scientific name of #284 (Adonidia merrillii)